### PR TITLE
fix: list `transitionDuration` in props

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -71,6 +71,7 @@ yarn add @webzlodimir/vue-bottom-sheet-vue2
 | z-index `v0.0.8`              | Number  | Set z-index of component card                                                                                                          | `:z-index="1001"`              | 99999      |
 | custom-class `v0.0.8`         | String  | The component custom class name                                                                                                        | `custom-class="custom-style"`  | ''         |
 | drag-color `v0.0.8`           | String  | Drag the bar icon color                                                                                                                | `drag-color="#ffc107"`         | #333333    |
+| transition-duration           | Number  | Transition animation duration                                                                                                          | `:transition-duration="0.5"`   | 0.5        |
 
 ## Events
 

--- a/README_CN.MD
+++ b/README_CN.MD
@@ -75,6 +75,7 @@ export default {
 | custom-class `v0.0.8`         | String  | 组件自定义类名                           | `custom-class="custom-style"`  | ''        |
 | init-sheet-height `v0.0.8`    | Number  | 设置窗口的初始高度，如果未设置，则采用内容高度           | `:init-sheet-height="300"`     | -         |
 | z-index `v0.0.8`              | Number  | 设置窗口的z-index                      | `:z-index="1001"`              | 99999     |
+| transition-duration           | Number  | 过渡动画持续时间                          | `:transition-duration="0.5"`   | 0.5       |
 
 ### custom-class说明
 

--- a/src/vue-bottom-sheet-vue2.vue
+++ b/src/vue-bottom-sheet-vue2.vue
@@ -84,7 +84,11 @@ export default {
     dragColor: {
       type: String,
       default: '#333333'
-    }
+    },
+    transitionDuration: {
+      type: Number,
+      default: 0.5,
+    },
   },
   data() {
     return {


### PR DESCRIPTION
Field `transitionDuration` is used in the component, but not defined, causing the `closed` event to fire earlier, than it should.

Here I defined a the prop with a default value of `0.5` - the same as in [Vue 3 version](https://github.com/vaban-ru/vue-bottom-sheet/blob/master/src/VueBottomSheet.vue#L63). Also updated readme.

There was one PR about it before that, bu I had to change the source branch.